### PR TITLE
Quickl fix for comstrek/air and fixed docker compose startup issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apt update && apt upgrade -y && \
 
 RUN git config --global url."git@github.com".insteadof "https://github.com/"
 
-RUN go install github.com/cosmtrek/air@latest
+# RUN go install github.com/cosmtrek/air@latest
+
+# Have to use a older version of air since i am using GO1.17(they require GO1.22)
+RUN go install github.com/cosmtrek/air@b3a0f1348a7584b7be0dbe9a7a61d63d6f181ce8
 
 CMD ["air"]

--- a/config.yml
+++ b/config.yml
@@ -2,9 +2,8 @@ payment_service_port: "tiger-payment:8001"
 inventory_service_port: "tiger-inventory:8000"
 service_port: "8080"
 
-inventory_config: 
+inventory_config:
   inventory_file_path: "./inventory.yml"
-
 #  UNCOMMENT FOR LOCAL W/O DOCKER
 # payment_service_port: ":8001"
 # inventory_service_port: ":8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,13 +34,13 @@ services:
       context: ../tigerlily-inventories
       target: dev
     volumes:
-      - ~/tiger-coders/tigerlily-inventories:/opt/tigercoders/inventories
+      - ~/tigercoders/tigerlily-inventories:/opt/tigercoders/inventories
       - ~/.ssh:/root/.ssh
     ports:
       - "8000:8000"
-    # NOT WORKING ON DOCKER UPDATE
-    # depends_on:
-    #   - tiger-db
+    # NOT WORKING ON DOCKER UPDATE; TODO: LATEST UPDATE(2024) SEEMS TO BE WORKING NOW
+    depends_on:
+      - db
 
   payment:
     container_name: tiger-payment
@@ -49,25 +49,26 @@ services:
       context: ../tigerlily-payment
       target: dev
     volumes:
-      - ~/tiger-coders/tigerlily-payment:/opt/tigercoders/payments
+      - ~/tigercoders/tigerlily-payment:/opt/tigercoders/payments
       - ~/.ssh:/root/.ssh
     ports:
       - "8001:8001"
     # NOT WORKING ON DOCKER UPDATE
-    # depends_on:
-    #   - tiger-db
+    depends_on:
+      - db
 
-  app:
-    container_name: tiger-app
-    build:
-      dockerfile: ../tigerlily-bakery/Dockerfile
-      context: ~/tiger-coders/tigerlily-bakery
-      target: dev
-    volumes:
-      - ~/tiger-coders/tigerlily-bakery:/opt/tigercoders/app
-      - /opt/tigercoders/app/node_modules
-    ports:
-      - "3000:3000"
+  # app:
+  #   container_name: tiger-app
+  #   build:
+  #     dockerfile: ../tigerlily-bakery/Dockerfile
+  #     # context: ~/tiger-coders/tigerlily-bakery
+  #     context: ../tigerlily-bakery
+  #     target: dev
+  #   volumes:
+  #     - ~/tiger-coders/tigerlily-bakery:/opt/tigercoders/app
+  #     - /opt/tigercoders/app/node_modules
+  #   ports:
+  #     - "3000:3000"
   
   # db:
   #   container_name: "tiger-db"


### PR DESCRIPTION
Comstrek/air has updated to require the use of golang >=1.22. i am however using go1.17. will upgrade go version sooon